### PR TITLE
Added changes in date picker for DateRangePicker

### DIFF
--- a/example/lib/modes/calendar_date_range_picker_widget.dart
+++ b/example/lib/modes/calendar_date_range_picker_widget.dart
@@ -28,12 +28,16 @@ class _CalendarDateRangePickerWidgetState
               firstDate: NepaliDateTime(1970),
               lastDate: NepaliDateTime(2100),
               onStartDateChanged: (date) {
-                dateRange.first = date;
-                setState(() {});
+                if (date != null) {
+                  dateRange.first = date;
+                  setState(() {});
+                }
               },
               onEndDateChanged: (date) {
-                dateRange.last = date;
-                setState(() {});
+                if (date != null) {
+                  dateRange.last = date;
+                  setState(() {});
+                }
               },
             ),
           ),

--- a/lib/src/material/date_picker.dart
+++ b/lib/src/material/date_picker.dart
@@ -1114,8 +1114,8 @@ class _CalendarRangePickerDialog extends StatelessWidget {
   final NepaliDateTime firstDate;
   final NepaliDateTime lastDate;
   final NepaliDateTime? currentDate;
-  final ValueChanged<NepaliDateTime> onStartDateChanged;
-  final ValueChanged<NepaliDateTime> onEndDateChanged;
+  final ValueChanged<NepaliDateTime?> onStartDateChanged;
+  final ValueChanged<NepaliDateTime?> onEndDateChanged;
   final VoidCallback? onConfirm;
   final VoidCallback? onCancel;
   final String confirmText;
@@ -1284,10 +1284,10 @@ class CalendarDateRangePicker extends StatefulWidget {
   final NepaliDateTime currentDate;
 
   /// Called when the user changes the start date of the selected range.
-  final ValueChanged<NepaliDateTime>? onStartDateChanged;
+  final ValueChanged<NepaliDateTime?> onStartDateChanged;
 
   /// Called when the user changes the end date of the selected range.
-  final ValueChanged<NepaliDateTime>? onEndDateChanged;
+  final ValueChanged<NepaliDateTime?> onEndDateChanged;
 
   @override
   _CalendarDateRangePickerState createState() =>
@@ -1370,14 +1370,14 @@ class _CalendarDateRangePickerState extends State<CalendarDateRangePicker> {
           _endDate == null &&
           !date.isBefore(_startDate!)) {
         _endDate = date;
-        widget.onEndDateChanged?.call(_endDate!);
+        widget.onEndDateChanged.call(_endDate!);
       } else {
         _startDate = date;
-        widget.onStartDateChanged?.call(_startDate!);
+        widget.onStartDateChanged.call(_startDate!);
         if (_endDate != null) {
           _endDate = null;
         } else {
-          widget.onEndDateChanged?.call(_endDate!);
+          widget.onEndDateChanged.call(_endDate!);
         }
       }
     });

--- a/lib/src/material/date_picker.dart
+++ b/lib/src/material/date_picker.dart
@@ -1266,15 +1266,7 @@ class CalendarDateRangePicker extends StatefulWidget {
         firstDate = utils.dateOnly(firstDate),
         lastDate = utils.dateOnly(lastDate),
         currentDate = utils.dateOnly(currentDate ?? NepaliDateTime.now()),
-        super(key: key) {
-    assert(
-        this.initialStartDate == null ||
-            this.initialEndDate == null ||
-            !this.initialStartDate!.isAfter(initialEndDate!),
-        'initialStartDate must be on or before initialEndDate.');
-    assert(!this.lastDate.isBefore(this.firstDate),
-        'firstDate must be on or before lastDate.');
-  }
+        super(key: key);
 
   /// The [NepaliDateTime] that represents the start of the initial date range selection.
   final NepaliDateTime? initialStartDate;
@@ -1384,6 +1376,7 @@ class _CalendarDateRangePickerState extends State<CalendarDateRangePicker> {
         widget.onStartDateChanged?.call(_startDate!);
         if (_endDate != null) {
           _endDate = null;
+        } else {
           widget.onEndDateChanged?.call(_endDate!);
         }
       }


### PR DESCRIPTION
The previous code snippet did not allow selecting an initial date past the end date. Also, there was an issue with the null check where the method was called after setting the value to null with the argument passed with a null check.

I have resolved those issues for DateTimeRangePicker.