### PR TITLE
fixed issue in assigning input decoration theme flutter version 3.5.x

### DIFF
--- a/lib/src/overrides/date_range_picker.dart
+++ b/lib/src/overrides/date_range_picker.dart
@@ -1892,7 +1892,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
     final MaterialLocalizations localizations = MaterialLocalizations.of(
       context,
     );
-    final InputDecorationTheme inputTheme = theme.inputDecorationTheme;
+    final InputDecorationThemeData inputTheme = theme.inputDecorationTheme;
     final InputBorder inputBorder =
         inputTheme.border ??
         (useMaterial3


### PR DESCRIPTION
For Flutter version 3.35.x, InputDecorationTheme no longer exists and instead InputDecorationThemeData is used, which is why there is compilation issue  with newer flutter version
@sarbagyastha , Please check this
Thanks

Fixes #33 